### PR TITLE
Add a hook to allow custom extensions or other code to affect the scene export

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneExporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneExporter.cs
@@ -1,4 +1,4 @@
-﻿#if UNITY_EDITOR
+#if UNITY_EDITOR
 #define ANIMATION_EXPORT_SUPPORTED
 #endif
 
@@ -183,6 +183,12 @@ namespace UnityGLTF
 			set { settings.SaveFolderPath = value; }
 		}
 #endif
+
+		public delegate bool OnExportNode(Transform transform, Node node);
+		public delegate bool OnExportScene(string name, GLTFScene scene, Transform[] rootObjTransforms);
+
+		public OnExportScene onExportScene;
+		public OnExportNode onExportNode;
 
 		private static int AnimationBakingFramerate = 30; // FPS
 		private static bool BakeAnimationData = true;
@@ -700,6 +706,10 @@ namespace UnityGLTF
 
 			_root.Scenes.Add(scene);
 
+			if (onExportScene != null) {
+				onExportScene(name, scene, rootObjTransforms);
+			}
+
 			return new SceneId
 			{
 				Id = _root.Scenes.Count - 1,
@@ -759,6 +769,11 @@ namespace UnityGLTF
 
 			// Register nodes for animation parsing (could be disabled is animation is disables)
 			_exportedTransforms.Add(nodeTransform.GetInstanceID(), _root.Nodes.Count);
+
+			if (onExportNode != null)
+			{
+				onExportNode(nodeTransform, node);
+			}
 
 			_root.Nodes.Add(node);
 

--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneExporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneExporter.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR
+﻿#if UNITY_EDITOR
 #define ANIMATION_EXPORT_SUPPORTED
 #endif
 
@@ -1285,7 +1285,7 @@ namespace UnityGLTF
             return false;
         }
 
-        private MaterialId ExportMaterial(Material materialObj)
+        public MaterialId ExportMaterial(Material materialObj)
 		{
             //TODO if material is null
 			MaterialId id = GetMaterialId(_root, materialObj);

--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneExporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneExporter.cs
@@ -706,9 +706,7 @@ namespace UnityGLTF
 
 			_root.Scenes.Add(scene);
 
-			if (onExportScene != null) {
-				onExportScene(name, scene, rootObjTransforms);
-			}
+			onExportScene?.Invoke(name, scene, rootObjTransforms);
 
 			return new SceneId
 			{
@@ -770,10 +768,7 @@ namespace UnityGLTF
 			// Register nodes for animation parsing (could be disabled is animation is disables)
 			_exportedTransforms.Add(nodeTransform.GetInstanceID(), _root.Nodes.Count);
 
-			if (onExportNode != null)
-			{
-				onExportNode(nodeTransform, node);
-			}
+			onExportNode?.Invoke(nodeTransform, node);
 
 			_root.Nodes.Add(node);
 

--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneExporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneExporter.cs
@@ -184,8 +184,8 @@ namespace UnityGLTF
 		}
 #endif
 
-		public delegate bool OnExportNode(Transform transform, Node node);
-		public delegate bool OnExportScene(string name, GLTFScene scene, Transform[] rootObjTransforms);
+		public delegate void OnExportNode(Transform transform, Node node);
+		public delegate void OnExportScene(string name, GLTFScene scene, Transform[] rootObjTransforms);
 
 		public OnExportScene onExportScene;
 		public OnExportNode onExportNode;


### PR DESCRIPTION
This allows extra extensions or extra materials to be added when needed.

An example of how to set this up
```
        var exportOptions = new ExportOptions { TexturePathRetriever = (texture) => { return AssetDatabase.GetAssetPath(texture); } };
        var exporter = new GLTFSceneExporter(new Transform[] { scene.transform }, exportOptions);
        GLTFSceneExporter.SaveFolderPath = outputPath;
        exporter.onExportScene += (string name, GLTFScene gltfScene, Transform[] rootObjTransforms) =>
        {
            //Execute code with GLTFScene context
        };
        exporter.SaveGLB(outputPath, scene.name);
```

Not sure how useful onExportNode would be, so that could be removed.