### PR TITLE
Expose ExportMesh API using PrimKey array

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,6 @@ TestProjects/*/UserSettings
 TestProjects/*/.vsconfig
 TestProjects/*/Builds
 TestProjects/*/Assets/WSATestCertificate.pfx*
+
+# MacOS Metadata
+.DS_Store


### PR DESCRIPTION
I'm implementing the `OMI_collider` extension as a UnityGLTF extension and I need to export the `sharedMesh` attached to a `MeshCollider`. In order to do so I need to be able to pass that shared mesh to the `ExportMesh` API. This PR changes `ExportMesh` and `ExportPrimitive` to operate on `PrimKey` instances instead of `GameObject` instances.