### PR TITLE
fix: don't invert glossmap scale with map

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneExporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneExporter.cs
@@ -2006,7 +2006,7 @@ namespace UnityGLTF
 				// legacy workaround: the UnityGLTF shaders misuse "_Glossiness" as roughness but don't have a keyword for it.
 				if (isGltfPbrMetallicRoughnessShader)
 					smoothness = 1 - smoothness;
-				pbr.RoughnessFactor = (metallicGlossMap && material.HasProperty("_GlossMapScale")) ? (1 - material.GetFloat("_GlossMapScale")) : (1.0 - smoothness);
+				pbr.RoughnessFactor = (metallicGlossMap && material.HasProperty("_GlossMapScale")) ? (material.GetFloat("_GlossMapScale")) : (1.0 - smoothness);
 			}
 
 			if (material.HasProperty("_MetallicGlossMap"))


### PR DESCRIPTION
**Problem:** When using Unity's Standard shader with a Metallic map and Smoothness data in the Alpha channel, and a Smoothness multiplier of `1`, upon export the Smoothness multiplier (`_GlossMapScale`) is inverted, resulting in a GLTF with a roughness multiplier value of `0`. Resulting in an entirely smooth material.


![Screen Shot 2022-11-16 at 19 48 08](https://user-images.githubusercontent.com/3521882/202269796-d42e9f26-e7e0-429c-96db-2ce11850db45.png)

![Screen Shot 2022-11-16 at 19 47 50](https://user-images.githubusercontent.com/3521882/202269814-f5f2a9e2-f851-4628-9dab-8dc79447e0d6.png)

**Proposed solution:** Don't invert the multiplier when a map is attached. If there is no map, then the smoothness should indeed continue to be inverted.

**Possible issue:** Majority of the time when using a gloss map, the multiplier would be `1`, however in cases it is less than `1`, as the smoothness data in the map is already inverted, the multiplier should be converted with `1.0 / _GlossMapScale`. Eg if the pixel smoothness data is `0.6`, and the multiplier is `0.8`, the smoothness value would be `0.48`. Therefore the desired roughness for that pixel would be `0.52`. As the pixel data is inverted, giving `0.4`, a multiplier of `1.25` would be required to achieve the desired value of `0.52`. Two issues with this, the potential of dividing by `0`, and that Unity doesn't support values above `1`.
