### PR TITLE
Errors when importing UnityGLTF dev branch because of JObject

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Plugins/GLTFSerialization/Extensions/GLTFJsonExtensions.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Plugins/GLTFSerialization/Extensions/GLTFJsonExtensions.cs
@@ -108,7 +108,7 @@ namespace GLTF.Extensions
 						Root = root
 					}
 				};
-				if (textureObject.ContainsKey(TextureInfo.TEXCOORD))
+				if (textureObject[TextureInfo.TEXCOORD] != null)
 				{
 					textureInfo.TexCoord = textureObject[TextureInfo.TEXCOORD].DeserializeAsInt();
 				}
@@ -124,7 +124,7 @@ namespace GLTF.Extensions
 			{
 				var normalTex = new NormalTextureInfo() { Index = tex.Index, TexCoord = tex.TexCoord };
 				JObject textureObject = token as JObject;
-				if (textureObject.ContainsKey(NormalTextureInfo.SCALE))
+				if (textureObject[NormalTextureInfo.SCALE] != null)
 				{
 					normalTex.Scale = textureObject[NormalTextureInfo.SCALE].DeserializeAsDouble();
 				}


### PR DESCRIPTION
UnityGLTF from the dev branch shows two errors in the console upon iport.

Reproducible with either of these Newtonsoft.Json-for-Unity dependencies:
https://assetstore.unity.com/packages/tools/input-management/json-net-for-unity-11347
https://github.com/jilleJr/Newtonsoft.Json-for-Unity

Unity shows two errors because JObject doesn't have a 'ContainsKey' method.
textureObject.ContainsKey(...)

Exact error:
Assets\UnityGLTF\Runtime\Plugins\GLTFSerialization\Extensions\GLTFJsonExtensions.cs(111,23): error CS1061: 'JObject' does not contain a definition for 'ContainsKey' and no accessible extension method 'ContainsKey' accepting a first argument of type 'JObject' could be found (are you missing a using directive or an assembly reference?)

I replaced the two instances where this happens with:
textureObject[...] != null