### PR TITLE
Ensure normal maps are exported as linear encoded .png textures

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/SceneExporter/ExporterTextures.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/SceneExporter/ExporterTextures.cs
@@ -104,9 +104,9 @@ namespace UnityGLTF
 		/// <param name="outputPath">The location to export the texture</param>
 		private void ExportNormalTexture(Texture2D texture, string outputPath)
 		{
-			var destRenderTexture = RenderTexture.GetTemporary(texture.width, texture.height, 0, RenderTextureFormat.ARGB32, RenderTextureReadWrite.sRGB);
+			var destRenderTexture = RenderTexture.GetTemporary(texture.width, texture.height, 0, RenderTextureFormat.ARGB32, RenderTextureReadWrite.Linear);
 			var wr = GL.sRGBWrite;
-			GL.sRGBWrite = true;
+			GL.sRGBWrite = false;
 			Graphics.Blit(texture, destRenderTexture, _normalChannelMaterial);
 			WriteRenderTextureToDiskAndRelease(destRenderTexture, outputPath, true);
 			GL.sRGBWrite = wr;
@@ -244,7 +244,8 @@ namespace UnityGLTF
 					break;
 			}
 
-			var canExportAsJpeg = !textureHasAlpha && settings.UseTextureFileTypeHeuristic;
+			var canExportAsJpeg =
+				!textureHasAlpha && settings.UseTextureFileTypeHeuristic && textureSlot != TextureMapType.Normal;
 			var desiredExtension = canExportAsJpeg ? ".jpg" : ".png";
 			if (textureSlot == TextureMapType.Custom_HDR)
 				desiredExtension = ".exr";


### PR DESCRIPTION
When I was working on some exporter features I kept noticing that reflections didn't look quite right on assets exported with UnityGLTF. It turns out UnityGLTF was converting normal maps to sRGB. Also normal maps are data textures and should generally be exported with lossless formats so I made them export as `.png` now.

You can see the issues with the following test asset:
https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/NormalTangentMirrorTest