### PR TITLE
Fix ORM map export TextureMapType

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneExporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneExporter.cs
@@ -189,7 +189,7 @@ namespace UnityGLTF
 				case TextureMapType.MetallicRoughness:
 					exportSettings.linear = true;
 					exportSettings.alphaMode = TextureExportSettings.AlphaMode.Never;
-					break;
+					return exportSettings;
 
 				case TextureMapType.SpecGloss: // SpecGloss = MetallicGloss; // not really supported anymore
 					exportSettings.linear = true;

--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/SceneExporter/ExporterMaterials.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/SceneExporter/ExporterMaterials.cs
@@ -244,7 +244,7 @@ namespace UnityGLTF
 				{
 					if(occTex is Texture2D)
 					{
-						material.OcclusionTexture = ExportOcclusionTextureInfo(occTex, TextureMapType.Linear, materialObj);
+						material.OcclusionTexture = ExportOcclusionTextureInfo(occTex, TextureMapType.Occlusion, materialObj);
 						ExportTextureTransform(material.OcclusionTexture, materialObj, propName);
 						material.OcclusionTexture.TexCoord = materialObj.HasProperty("occlusionTextureTexCoord") ?
 							Mathf.RoundToInt(materialObj.GetFloat("occlusionTextureTexCoord")) :
@@ -676,7 +676,7 @@ namespace UnityGLTF
 				var mrTex = material.GetTexture("metallicRoughnessTexture");
 				if (mrTex)
 				{
-					pbr.MetallicRoughnessTexture = ExportTextureInfo(mrTex, TextureMapType.Linear);
+					pbr.MetallicRoughnessTexture = ExportTextureInfo(mrTex, TextureMapType.MetallicRoughness);
 				}
 			}
 			else if (material.HasProperty("_MetallicRoughnessTexture"))
@@ -684,7 +684,7 @@ namespace UnityGLTF
 				var mrTex = material.GetTexture("_MetallicRoughnessTexture");
 				if (mrTex)
 				{
-					pbr.MetallicRoughnessTexture = ExportTextureInfo(mrTex, TextureMapType.Linear);
+					pbr.MetallicRoughnessTexture = ExportTextureInfo(mrTex, TextureMapType.MetallicRoughness);
 				}
 			}
 			else if (material.HasProperty("_MetallicGlossMap"))


### PR DESCRIPTION
Occlusion and MetallicRoughness textures were being exported with an empty alpha channel. I've fixed a few places where material slots were being set to the incorrect TextureMapType.