### PR TITLE
Target-names from mesh extras properties validation

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Plugins/GLTFSerialization/Schema/GLTFMesh.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Plugins/GLTFSerialization/Schema/GLTFMesh.cs
@@ -101,6 +101,7 @@ namespace GLTF.Schema
 					foreach (MeshPrimitive mp in mesh.Primitives)
 					{
 						if (mp == null) continue;
+						if(mp.Targets == null || mp.Targets.Count != mesh.TargetNames.Count) throw new GLTFParseException("Invalid number of morphtarget names on mesh!");
 						mp.TargetNames = mesh.TargetNames;
 					}
 				}

--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Plugins/GLTFSerialization/Schema/GLTFMesh.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Plugins/GLTFSerialization/Schema/GLTFMesh.cs
@@ -102,7 +102,6 @@ namespace GLTF.Schema
 					{
 						if (mp == null) continue;
 						if(mp.Targets == null || mp.Targets.Count != mesh.TargetNames.Count) throw new GLTFParseException("Invalid number of morphtarget names on mesh!");
-						mp.TargetNames = mesh.TargetNames;
 					}
 				}
 			}

--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/SceneImporter/ImporterMeshes.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/SceneImporter/ImporterMeshes.cs
@@ -150,15 +150,29 @@ namespace UnityGLTF
 
 			if (unityMeshData.MorphTargetVertices != null)
 			{
-				var firstPrim = _gltfRoot.Meshes[meshIndex].Primitives[0];
-				for (int i = 0; i < firstPrim.Targets.Count; i++)
-				{
-					var targetName = firstPrim.TargetNames != null ? firstPrim.TargetNames[i] : $"Morphtarget{i}";
-					mesh.AddBlendShapeFrame(targetName, 100,
-						unityMeshData.MorphTargetVertices[i],
-						unityMeshData.MorphTargetNormals != null ? unityMeshData.MorphTargetNormals[i] : null,
-						unityMeshData.MorphTargetTangents != null ? unityMeshData.MorphTargetTangents[i] : null
-					);
+				if(_gltfRoot.Meshes[meshIndex].TargetNames != null && _gltfRoot.Meshes[meshIndex].TargetNames.Count > 0)
+				{	// Get target names from mesh extras
+					for (int i = 0; i < _gltfRoot.Meshes[meshIndex].TargetNames.Count; i++)
+					{
+						var targetName = _gltfRoot.Meshes[meshIndex].TargetNames[i] != null && _gltfRoot.Meshes[meshIndex].TargetNames[i].Length > 0 ? _gltfRoot.Meshes[meshIndex].TargetNames[i] : $"Morphtarget{i}";
+						mesh.AddBlendShapeFrame(targetName, 100,
+							unityMeshData.MorphTargetVertices[i],
+							unityMeshData.MorphTargetNormals != null ? unityMeshData.MorphTargetNormals[i] : null,
+							unityMeshData.MorphTargetTangents != null ? unityMeshData.MorphTargetTangents[i] : null
+						);
+					}
+				} else {
+					// Get target names from first primitive's extras
+					var firstPrim = _gltfRoot.Meshes[meshIndex].Primitives[0];
+					for (int i = 0; i < firstPrim.Targets.Count; i++)
+					{
+						var targetName = firstPrim.TargetNames != null ? firstPrim.TargetNames[i] : $"Morphtarget{i}";
+						mesh.AddBlendShapeFrame(targetName, 100,
+							unityMeshData.MorphTargetVertices[i],
+							unityMeshData.MorphTargetNormals != null ? unityMeshData.MorphTargetNormals[i] : null,
+							unityMeshData.MorphTargetTangents != null ? unityMeshData.MorphTargetTangents[i] : null
+						);
+					}
 				}
 			}
 			await YieldOnTimeoutAndThrowOnLowMemory();


### PR DESCRIPTION
As requested here in my [previous PR](https://github.com/prefrontalcortex/UnityGLTF/pull/70) the length of the target names array gets validated against the number of morphtargets in each mesh primitive.

Additionally, the blendshape-names for unity's datastructure are now taken from the mesh instead of from the first mesh primitive, if present.

Note: ill be gone for a week. After that ill gladly respond if there is any comments or issues with this PR.