### PR TITLE
Uncomment usage of ShouldExportTransform

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneExporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/GLTFSceneExporter.cs
@@ -855,7 +855,7 @@ namespace UnityGLTF
 			scene.Nodes = new List<NodeId>(rootObjTransforms.Length);
 			foreach (var transform in rootObjTransforms)
 			{
-				// if(!ShouldExportTransform(transform)) continue;
+				if(!ShouldExportTransform(transform)) continue;
 				scene.Nodes.Add(ExportNode(transform));
 			}
 


### PR DESCRIPTION
This check is used to ignore disabled nodes in the export. I'm not sure why it was commented out, but I've uncommented it so that we can ignore disabled nodes again.