### PR TITLE
Blendshape Sparse Accessors import fix

### DIFF
--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/SceneImporter/ImporterMeshes.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/SceneImporter/ImporterMeshes.cs
@@ -492,7 +492,6 @@ namespace UnityGLTF
 					var current = att[NormalKey].AccessorContent;
 					NumericArray before = new NumericArray();
 					before.AsVec3s = new GLTF.Math.Vector3[current.AsVec3s.Length];
-					Array.Copy(current.AsVec3s, before.AsVec3s, before.AsVec3s.Length);
 					for (int j = 0; j < sparseNormals[1].AsUInts.Length; j++)
 					{
 						before.AsVec3s[sparseNormals[1].AsUInts[j]] = sparseNormals[0].AsVec3s[j];
@@ -505,7 +504,6 @@ namespace UnityGLTF
 					var current = att[PositionKey].AccessorContent;
 					NumericArray before = new NumericArray();
 					before.AsVec3s = new GLTF.Math.Vector3[current.AsVec3s.Length];
-					Array.Copy(current.AsVec3s, before.AsVec3s, before.AsVec3s.Length);
 					for (int j = 0; j < sparsePositions[1].AsUInts.Length; j++)
 					{
 						before.AsVec3s[sparsePositions[1].AsUInts[j]] = sparsePositions[0].AsVec3s[j];
@@ -518,7 +516,6 @@ namespace UnityGLTF
 					var current = att[TangentKey].AccessorContent;
 					NumericArray before = new NumericArray();
 					before.AsVec3s = new GLTF.Math.Vector3[current.AsVec3s.Length];
-					Array.Copy(current.AsVec3s, before.AsVec3s, before.AsVec3s.Length);
 					for (int j = 0; j < sparseTangents[1].AsUInts.Length; j++)
 					{
 						before.AsVec3s[sparseTangents[1].AsUInts[j]] = sparseTangents[0].AsVec3s[j];

--- a/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/SceneImporter/ImporterMeshes.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Runtime/Scripts/SceneImporter/ImporterMeshes.cs
@@ -402,9 +402,9 @@ namespace UnityGLTF
 				NumericArray[] sparsePositions = null;
 				NumericArray[] sparseTangents = null;
 
-				const string NormalKey = "NORMALS";
-				const string PositionKey = "POSITIONS";
-				const string TangentKey = "TANGENTS";
+				const string NormalKey = "NORMAL";
+				const string PositionKey = "POSITION";
+				const string TangentKey = "TANGENT";
 
 				// normals, positions, tangents
 				foreach (var targetAttribute in target)


### PR DESCRIPTION
Fixed wrong imported blend shapes when using Sparse Accessors
![image](https://github.com/prefrontalcortex/UnityGLTF/assets/118285915/81bde956-fd5c-4f80-a12b-ffc3b226d7a8)
