### PR TITLE
Blendshape name import option

### DIFF
--- a/Editor/Scripts/GLTFImporter.cs
+++ b/Editor/Scripts/GLTFImporter.cs
@@ -89,6 +89,8 @@ namespace UnityGLTF
         [SerializeField] internal bool _generateColliders = false;
         [SerializeField] internal bool _swapUvs = false;
         [SerializeField] internal bool _generateLightmapUVs = false;
+	    [Tooltip("When false, the index of the BlendShape is used as name.")]
+        [SerializeField] internal bool _importBlendShapeNames = true;
         [SerializeField] internal GLTFImporterNormals _importNormals = GLTFImporterNormals.Import;
         [SerializeField] internal GLTFImporterNormals _importTangents = GLTFImporterNormals.Import;
         [SerializeField] internal AnimationMethod _importAnimations = AnimationMethod.Mecanim;
@@ -797,7 +799,8 @@ namespace UnityGLTF
 			    ImportContext = context,
 			    SwapUVs = _swapUvs,
 			    ImportNormals = _importNormals,
-			    ImportTangents = _importTangents
+			    ImportTangents = _importTangents,
+			    ImportBlendShapeNames = _importBlendShapeNames
 		    };
 
 		    using (var stream = File.OpenRead(projectFilePath))

--- a/Editor/Scripts/GLTFImporterInspector.cs
+++ b/Editor/Scripts/GLTFImporterInspector.cs
@@ -77,6 +77,8 @@ namespace UnityGLTF
 			EditorGUILayout.LabelField("Meshes", EditorStyles.boldLabel);
 			EditorGUILayout.PropertyField(serializedObject.FindProperty(nameof(GLTFImporter._readWriteEnabled)), new GUIContent("Read/Write"));
 			EditorGUILayout.PropertyField(serializedObject.FindProperty(nameof(GLTFImporter._generateColliders)));
+			EditorGUILayout.PropertyField(serializedObject.FindProperty(nameof(GLTFImporter._importBlendShapeNames)));
+			
 			EditorGUILayout.Separator();
 			
 			EditorGUILayout.LabelField("Geometry", EditorStyles.boldLabel);

--- a/Runtime/Scripts/GLTFSceneImporter.cs
+++ b/Runtime/Scripts/GLTFSceneImporter.cs
@@ -44,6 +44,7 @@ namespace UnityGLTF
 		public bool SwapUVs = false;
 		public GLTFImporterNormals ImportNormals = GLTFImporterNormals.Import;
 		public GLTFImporterNormals ImportTangents = GLTFImporterNormals.Import;
+		public bool ImportBlendShapeNames = true;
 
 #if UNITY_EDITOR
 		public GLTFImportContext ImportContext = new GLTFImportContext(null, new List<GltfImportPluginContext>());

--- a/Runtime/Scripts/SceneImporter/ImporterAnimation.cs
+++ b/Runtime/Scripts/SceneImporter/ImporterAnimation.cs
@@ -311,7 +311,7 @@ namespace UnityGLTF
 							var targetNames = prim.TargetNames;
 							propertyNames = new string[targetCount];
 							for (var i = 0; i < targetCount; i++)
-								propertyNames[i] = "blendShape." + (targetNames != null ? targetNames[i] : ("Morphtarget" + i));
+								propertyNames[i] = _options.ImportBlendShapeNames ? ("blendShape." + (targetNames != null ? targetNames[i] : ("Morphtarget" + i))) : i.ToString();
 
 							var frameFloats = new float[targetCount];
 

--- a/Runtime/Scripts/SceneImporter/ImporterAnimation.cs
+++ b/Runtime/Scripts/SceneImporter/ImporterAnimation.cs
@@ -311,8 +311,7 @@ namespace UnityGLTF
 							var targetNames = prim.TargetNames;
 							propertyNames = new string[targetCount];
 							for (var i = 0; i < targetCount; i++)
-								propertyNames[i] = _options.ImportBlendShapeNames ? ("blendShape." + (targetNames != null ? targetNames[i] : ("Morphtarget" + i))) : i.ToString();
-
+								propertyNames[i] = _options.ImportBlendShapeNames ? ("blendShape." + (targetNames != null ? targetNames[i] : ("Morphtarget" + i))) : "blendShape."+i.ToString();
 							var frameFloats = new float[targetCount];
 
 							SetAnimationCurve(clip, relativePath, propertyNames, input, output,

--- a/Runtime/Scripts/SceneImporter/ImporterMeshes.cs
+++ b/Runtime/Scripts/SceneImporter/ImporterMeshes.cs
@@ -511,7 +511,7 @@ namespace UnityGLTF
 				var firstPrim = _gltfRoot.Meshes[meshIndex].Primitives[0];
 				for (int i = 0; i < firstPrim.Targets.Count; i++)
 				{
-					var targetName = firstPrim.TargetNames != null ? firstPrim.TargetNames[i] : $"Morphtarget{i}";
+					var targetName = _options.ImportBlendShapeNames ? (firstPrim.TargetNames != null ? firstPrim.TargetNames[i] : $"Morphtarget{i}") : i.ToString();
 					mesh.AddBlendShapeFrame(targetName, 1f,
 						unityMeshData.MorphTargetVertices[i],
 						unityMeshData.MorphTargetNormals != null ? unityMeshData.MorphTargetNormals[i] : null,


### PR DESCRIPTION
Added new import option for Blend Shape Names. 
When it's disabled, only the blendshape index will be used as name.