### PR TITLE
Runtime fixes

### DIFF
--- a/Runtime/Scripts/GLTFSceneImporter.cs
+++ b/Runtime/Scripts/GLTFSceneImporter.cs
@@ -48,7 +48,7 @@ namespace UnityGLTF
 #if UNITY_EDITOR
 		public GLTFImportContext ImportContext = new GLTFImportContext(null, new List<GltfImportPluginContext>());
 #else
-		public GLTFImportContext ImportContext;
+		public GLTFImportContext ImportContext = new GLTFImportContext(new List<GltfImportPluginContext>());
 #endif
 
 		[NonSerialized]

--- a/Runtime/Scripts/GLTFSceneImporter.cs
+++ b/Runtime/Scripts/GLTFSceneImporter.cs
@@ -289,16 +289,7 @@ namespace UnityGLTF
 			else
 				Debug = UnityEngine.Debug.unityLogger;
 
-			if (_options.DataLoader == null)
-			{
-				if (_options.ExternalDataLoader == null)
-				{
-					_options.DataLoader = new UnityWebRequestLoader(URIHelper.GetDirectoryName(gltfFileName));
-					_gltfFileName = URIHelper.GetFileFromUri(new Uri(_gltfFileName));
-				}
-				else
-					_options.DataLoader = LegacyLoaderWrapper.Wrap(_options.ExternalDataLoader);
-			}
+			VerifyDataLoader();
 		}
 
 		public GLTFSceneImporter(GLTFRoot rootNode, Stream gltfStream, ImportOptions options)
@@ -316,9 +307,20 @@ namespace UnityGLTF
 			}
 
 			_options = options;
+			VerifyDataLoader();
+		}
+
+		private void VerifyDataLoader()
+		{
 			if (_options.DataLoader == null)
 			{
-				_options.DataLoader = LegacyLoaderWrapper.Wrap(_options.ExternalDataLoader);
+				if (_options.ExternalDataLoader == null)
+				{
+					_options.DataLoader = new UnityWebRequestLoader(URIHelper.GetDirectoryName(_gltfFileName));
+					_gltfFileName = URIHelper.GetFileFromUri(new Uri(_gltfFileName));
+				}
+				else
+					_options.DataLoader = LegacyLoaderWrapper.Wrap(_options.ExternalDataLoader);
 			}
 		}
 

--- a/Runtime/Scripts/GLTFSceneImporter.cs
+++ b/Runtime/Scripts/GLTFSceneImporter.cs
@@ -37,7 +37,7 @@ namespace UnityGLTF
 		public IDataLoader DataLoader = null;
 		public AsyncCoroutineHelper AsyncCoroutineHelper = null;
 		public bool ThrowOnLowMemory = true;
-		public AnimationMethod AnimationMethod = AnimationMethod.Mecanim;
+		public AnimationMethod AnimationMethod = AnimationMethod.Legacy;
 		public bool AnimationLoopTime = true;
 		public bool AnimationLoopPose = false;
 

--- a/Runtime/Scripts/GLTFSceneImporter.cs
+++ b/Runtime/Scripts/GLTFSceneImporter.cs
@@ -291,7 +291,13 @@ namespace UnityGLTF
 
 			if (_options.DataLoader == null)
 			{
-				_options.DataLoader = LegacyLoaderWrapper.Wrap(_options.ExternalDataLoader);
+				if (_options.ExternalDataLoader == null)
+				{
+					_options.DataLoader = new UnityWebRequestLoader(URIHelper.GetDirectoryName(gltfFileName));
+					_gltfFileName = URIHelper.GetFileFromUri(new Uri(_gltfFileName));
+				}
+				else
+					_options.DataLoader = LegacyLoaderWrapper.Wrap(_options.ExternalDataLoader);
 			}
 		}
 

--- a/Runtime/Scripts/Plugins/ImportContext.cs
+++ b/Runtime/Scripts/Plugins/ImportContext.cs
@@ -30,6 +30,10 @@ namespace UnityGLTF.Plugins
 				SourceImporter = AssetImporter.GetAtPath(assetImportContext.assetPath);
 		}
 #endif
+		internal GLTFImportContext(IReadOnlyList<GltfImportPluginContext> plugins)
+		{
+			Plugins = plugins;
+		}
 	}
 
 	public interface IGLTFImportRemap

--- a/Runtime/Scripts/SceneImporter/ImporterAnimation.cs
+++ b/Runtime/Scripts/SceneImporter/ImporterAnimation.cs
@@ -161,7 +161,12 @@ namespace UnityGLTF
 
 				// copy all key frames data to animation curve and add it to the clip
 				AnimationCurve curve = new AnimationCurve(keyframes[ci]);
-				clip.SetCurve(relativePath, curveType, propertyNames[ci], curve);
+				
+#if !UNITY_EDITOR
+				// Only in editor SetCurve works with non-legacy clips
+				if (clip.legacy)
+#endif 
+					clip.SetCurve(relativePath, curveType, propertyNames[ci], curve);
 			}
 		}
 

--- a/Runtime/Scripts/SceneImporter/ImporterMeshes.cs
+++ b/Runtime/Scripts/SceneImporter/ImporterMeshes.cs
@@ -170,11 +170,9 @@ namespace UnityGLTF
 
 					var draco = new DracoMeshLoader();
 
-#if UNITY_EDITOR
 					dracoDecodeResults[i] = await draco.ConvertDracoMeshToUnity(meshDataArray[i], bufferViewData,
 						needsNormals, needsTangents,
 						weightsAttributeId, jointsAttributeId, firstPrim.Targets != null);
-#endif
 
 					if (!dracoDecodeResults[i].success)
 					{

--- a/Runtime/Scripts/Timeline/GLTFRecorder.cs
+++ b/Runtime/Scripts/Timeline/GLTFRecorder.cs
@@ -345,12 +345,14 @@ namespace UnityGLTF.Timeline
 				extremePointsOnBounds[4] = translationBounds.center + new Vector3(0, 0, +translationBounds.extents.z);
 				extremePointsOnBounds[5] = translationBounds.center + new Vector3(0, 0, -translationBounds.extents.z);
 
+				int index = 0;
 				foreach (var point in extremePointsOnBounds)
 				{
 					var cubeInstance = Object.Instantiate(cube);
-					cubeInstance.name = "AnimationBounds";
+					cubeInstance.name = $"AnimationBounds {index.ToString()}";
 					cubeInstance.transform.position = point;
 					cubeInstance.transform.parent = boundsRoot.transform;
+					index++;
 				}
 
 				// export and add explicitly to the scene list, otherwise these nodes at the root level will be ignored


### PR DESCRIPTION
Fixes for issues at runtime: 

- added default DataLoader to GLTFSceneImporter
- added default GLTFImportContext 
- changed AnimationMethod to legacy (only in Editor the animation curves can be set for Mecanim Animation Clips) 
- wrong placed #if for draco decompression