### PR TITLE
Ensure valid tangent.w value on mesh export

### DIFF
--- a/Runtime/Scripts/Extensions/SchemaExtensions.cs
+++ b/Runtime/Scripts/Extensions/SchemaExtensions.cs
@@ -528,6 +528,27 @@ namespace UnityGLTF.Extensions
 
 			return returnArray;
 		}
+		
+		/// <summary>
+		/// Converts and copies based on the specified coordinate scale. Also verify the tangent.w component to be -1 or 1
+		/// </summary>
+		/// <param name="array">The array to convert and copy</param>
+		/// <param name="coordinateSpaceCoordinateScale">The specified coordinate space</param>
+		/// <returns>The copied and converted coordinate space</returns>
+		public static Vector4[] ConvertTangentCoordinateSpaceAndCopy(Vector4[] array, GLTF.Math.Vector4 coordinateSpaceCoordinateScale)
+		{
+			var returnArray = new Vector4[array.Length];
+			var coordinateScale = coordinateSpaceCoordinateScale.ToUnityVector4Raw();
+
+			for (var i = 0; i < array.Length; i++)
+			{
+				returnArray[i] = array[i];
+				returnArray[i].w = Mathf.Sign(returnArray[i].w);
+				returnArray[i].Scale(coordinateScale);
+			}
+
+			return returnArray;
+		}		
 
 		/// <summary>
 		/// Rewinds the indicies into Unity coordinate space from glTF space

--- a/Runtime/Scripts/SceneExporter/ExporterMeshes.cs
+++ b/Runtime/Scripts/SceneExporter/ExporterMeshes.cs
@@ -253,7 +253,7 @@ namespace UnityGLTF
 					aNormal = ExportAccessor(SchemaExtensions.ConvertVector3CoordinateSpaceAndCopy(meshObj.normals, SchemaExtensions.CoordinateSpaceConversionScale));
 
 				if (meshObj.tangents.Length != 0)
-					aTangent = ExportAccessor(SchemaExtensions.ConvertVector4CoordinateSpaceAndCopy(meshObj.tangents, SchemaExtensions.TangentSpaceConversionScale));
+					aTangent = ExportAccessor(SchemaExtensions.ConvertTangentCoordinateSpaceAndCopy(meshObj.tangents, SchemaExtensions.TangentSpaceConversionScale));
 
 				if (meshObj.uv.Length != 0)
 					aTexcoord0 = ExportAccessor(SchemaExtensions.FlipTexCoordArrayVAndCopy(meshObj.uv));


### PR DESCRIPTION
Meta Avatar Meshes have invalid tangent.w values:

![image](https://github.com/prefrontalcortex/UnityGLTF/assets/118285915/d23fc059-d861-4872-a4c3-98be1f449dcc)

Gltf validation requires a tangents.w value to be -1 or 1, so i added mathf.sign to the tangent export, to ensure that.
