### PR TITLE
Timeline recorder and animation import fix

### DIFF
--- a/Runtime/Scripts/SceneImporter/ImporterAnimation.cs
+++ b/Runtime/Scripts/SceneImporter/ImporterAnimation.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using GLTF;
@@ -147,6 +148,25 @@ namespace UnityGLTF
 				}
 			}
 
+			if (mode == InterpolationType.LINEAR && channelCount == 4 && propertyNames.All(p => p == "localRotation.x" || p == "localRotation.y" || p == "localRotation.z" || p == "localRotation.w"))
+			{
+				Quaternion prev = Quaternion.identity;
+				for (int i = 0; i < keyframes[0].Length; i++)
+				{
+					Quaternion q = new Quaternion(keyframes[0][i].value, keyframes[1][i].value, keyframes[2][i].value, keyframes[3][i].value);
+					if (i > 0)
+					{
+						if (Quaternion.Dot(prev, q) < 0)
+							q = new Quaternion(-q.x, -q.y, -q.z, -q.w);
+						
+						keyframes[0][i].value = q.x;
+						keyframes[1][i].value = q.y;
+						keyframes[2][i].value = q.z;
+						keyframes[3][i].value = q.w;
+					}
+				}
+			}
+			
 			for (var ci = 0; ci < channelCount; ++ci)
 			{
 				if (mode != InterpolationType.CUBICSPLINE)

--- a/Runtime/Scripts/SceneImporter/ImporterAnimation.cs
+++ b/Runtime/Scripts/SceneImporter/ImporterAnimation.cs
@@ -164,10 +164,11 @@ namespace UnityGLTF
 						keyframes[2][i].value = q.z;
 						keyframes[3][i].value = q.w;
 					}
+					prev = q;
 				}
 			}
 			
-			for (var ci = 0; ci < channelCount; ++ci)
+			for (var ci = 0; ci < channelCount; ci++)
 			{
 				if (mode != InterpolationType.CUBICSPLINE)
 				{

--- a/Runtime/Scripts/Timeline/GLTFRecorderBehaviour.cs
+++ b/Runtime/Scripts/Timeline/GLTFRecorderBehaviour.cs
@@ -36,7 +36,7 @@ namespace UnityGLTF.Timeline
 	    {
 		    if (recorder == null)
 		    {
-			    recorder = new GLTFRecorder(getExportRoot, Clip.m_RecordBlendShapes, Clip.m_RecordAnimationPointer);
+			    recorder = new GLTFRecorder(getExportRoot, Clip.m_RecordBlendShapes, recordAnimationPointer: Clip.m_RecordAnimationPointer);
 			    recorder.AnimationName = Clip.m_AnimationName;
 			    recorder.StartRecording(getTime);
 		    }


### PR DESCRIPTION
- fixed in timeline recorder wrong assigned parameters in GLTFRecorder constructor 

- animation import: added custom solution for AnimationClip.EnsureQuaternionContinuity for linear interpolation 
(AnimationClip.EnsureQuaternionContinuity can't be used because it smoothes the curves). 

