### PR TITLE
Import scale fix

### DIFF
--- a/Editor/Scripts/GLTFImporter.cs
+++ b/Editor/Scripts/GLTFImporter.cs
@@ -400,6 +400,19 @@ namespace UnityGLTF
 	                        vertexBuffer[i] *= _scaleFactor;
 	                    }
 	                    mesh.SetVertices(vertexBuffer);
+
+	                    if (mesh.bindposes != null && mesh.bindposes.Length > 0)
+	                    {
+		                    var bindPoses = mesh.bindposes;
+		                    for (var i = 0; i < bindPoses.Length; ++i)
+		                    {
+			                    bindPoses[i].GetTRSProperties(out var p, out var q, out var s);
+			                    bindPoses[i].SetTRS(p * _scaleFactor, q, s);
+		                    }
+
+		                    mesh.bindposes = bindPoses;
+	                    }
+	     
                     }
                     if (_generateLightmapUVs)
                     {

--- a/Editor/Scripts/GLTFImporter.cs
+++ b/Editor/Scripts/GLTFImporter.cs
@@ -25,6 +25,7 @@ using Object = UnityEngine.Object;
 using UnityGLTF.Loader;
 using GLTF.Schema;
 using GLTF;
+using UnityGLTF.Extensions;
 using UnityGLTF.Plugins;
 #if UNITY_2020_2_OR_NEWER
 using UnityEditor.AssetImporters;
@@ -827,6 +828,7 @@ namespace UnityGLTF
 			    loader.LoadUnreferencedImagesAndMaterials = true;
 			    loader.MaximumLod = _maximumLod;
 			    loader.IsMultithreaded = true;
+			    loader._importScaleFactor = _scaleFactor;
 
 			    // Need to call with RunSync, otherwise the draco loader will freeze the editor
 			    AsyncHelpers.RunSync(() => loader.LoadSceneAsync());

--- a/Runtime/Scripts/GLTFSceneImporter.cs
+++ b/Runtime/Scripts/GLTFSceneImporter.cs
@@ -275,6 +275,10 @@ namespace UnityGLTF
 		protected AssetCache _assetCache;
 		protected bool _isRunning = false;
 
+#if UNITY_EDITOR
+		internal float _importScaleFactor = 1f;
+#endif
+		
 		protected ImportProgress progressStatus = default(ImportProgress);
 		protected IProgress<ImportProgress> progress = null;
 

--- a/Runtime/Scripts/SceneImporter/ImporterAnimation.cs
+++ b/Runtime/Scripts/SceneImporter/ImporterAnimation.cs
@@ -294,7 +294,11 @@ namespace UnityGLTF
 										  (data, frame) =>
 										  {
 											  var position = data.AsVec3s[frame].ToUnityVector3Convert();
+#if UNITY_EDITOR
+											  return new float[] { position.x * _importScaleFactor, position.y * _importScaleFactor, position.z * _importScaleFactor};
+#else
 											  return new float[] { position.x, position.y, position.z };
+#endif
 										  });
 						break;
 


### PR DESCRIPTION
Fixed wrong imported SkinnedMesh when import scale != 1.
Also fixed position properties in animation clips when the import scale was changed.